### PR TITLE
Transparency (Added alpha channel to yarn diffuse colors.)

### DIFF
--- a/frontends/standalone_pattern_editor/main.cpp
+++ b/frontends/standalone_pattern_editor/main.cpp
@@ -27,8 +27,15 @@ int main(int argc, char **argv)
 	uint32_t pattern_width = 2;
 	uint32_t pattern_height = 2;
 	tlColor yarn_colors[2];
-	yarn_colors[0].r = 0.6f; yarn_colors[0].g = 0.6f; yarn_colors[0].b = 0.6f;
-	yarn_colors[1].r = 0.2f; yarn_colors[1].g = 0.2f; yarn_colors[1].b = 0.2f;
+	yarn_colors[0].r = 0.6f;
+    yarn_colors[0].g = 0.6f;
+    yarn_colors[0].b = 0.6f;
+    yarn_colors[0].a = 1.0f;
+
+	yarn_colors[1].r = 0.2f;
+    yarn_colors[1].g = 0.2f;
+    yarn_colors[1].b = 0.2f;
+    yarn_colors[1].a = 1.0f;
 	uint32_t num_yarn_types = 2;
 	tlWeaveParameters* params = tl_weave_pattern_from_data(
 		warp_above,yarn_type,num_yarn_types,yarn_colors,

--- a/frontends/vray/vray_thunderloom.h
+++ b/frontends/vray/vray_thunderloom.h
@@ -28,6 +28,7 @@ class BRDFThunderLoomSampler: public VR::BRDFSampler, public VR::BSDFSampler {
     VR::ShadeVec m_uv;
     VR::ShadeTransform m_uv_tm;
     VR::ShadeCol m_diffuse_color;
+    float m_diffuse_color_alpha;
     tlYarnType m_yarn_type;
     int m_yarn_type_id;
 

--- a/frontends/vray/vray_thunderloom_updated.cpp
+++ b/frontends/vray/vray_thunderloom_updated.cpp
@@ -19,11 +19,11 @@ BRDFThunderLoomParamsUpdated::BRDFThunderLoomParamsUpdated(void) {
 	addParamPlugin("twist", EXT_TEXTURE_FLOAT, 0, "How strongly to simulate the twisting nature of the yarn. Usually synthetic yarns, such as polyester, have less twist than organic yarns, such as cotton.");
 	addParamPlugin("phase_alpha", EXT_TEXTURE_FLOAT, 0, "Alpha value. Constant term to the fiber scattering function.");
 	addParamPlugin("phase_beta", EXT_TEXTURE_FLOAT, 0, "Beta value. Directionality intensity of the fiber scattering function.");
-	addParamTexture("specular_color", Color(0.4f, 0.4f, 0.4f), 0, "Color of the specular reflections. This will implicitly affect the strength of the diffuse reflections.");
+	addParamTexture("specular_color", AColor(0.4f, 0.4f, 0.4f, 1.f), 0, "Color of the specular reflections. This will implicitly affect the strength of the diffuse reflections.");
 	addParamPlugin("specular_color_amount", EXT_TEXTURE_FLOAT, 0, "Factor to multiply specular color with.");
 	addParamPlugin("specular_noise", EXT_TEXTURE_FLOAT, 0, "Noise on specular reflections.");
 	addParamPlugin("highlight_width", EXT_TEXTURE_FLOAT, 0, "Width over which to average the specular reflections. Gives wider highlight streaks on the yarns.");
-	addParamTexture("diffuse_color", Color(0.f, 0.3f, 0.f), 0, "Diffuse color.");
+	addParamTexture("diffuse_color", AColor(0.f, 0.3f, 0.f, 1.f), 0, "Diffuse color.");
 	addParamPlugin("diffuse_color_amount", EXT_TEXTURE_FLOAT, 0, "Factor to multiply diffuse color with.");
 	
 	// Stored as lists, just like above. These parameters allow us to 
@@ -201,9 +201,12 @@ TL_VRAY_FLOAT_PARAMS
 
         if (is_param_valid(diffuse_color, i)) {
             if (!set_texparam(diffuse_color, &yarn_type->color_texmap, i)) {
-                Color tmp_diffuse_color = diffuse_color->getColor(i);
+                AColor tmp_diffuse_color = diffuse_color->getAColor(i);
                 tlColor tl_diffuse_color;
-                tl_diffuse_color.r = tmp_diffuse_color.r; tl_diffuse_color.g = tmp_diffuse_color.g; tl_diffuse_color.b = tmp_diffuse_color.b;
+                tl_diffuse_color.r = tmp_diffuse_color.color.r;
+                tl_diffuse_color.g = tmp_diffuse_color.color.g;
+                tl_diffuse_color.b = tmp_diffuse_color.color.b;
+                tl_diffuse_color.a = tmp_diffuse_color.alpha;
                 yarn_type->color = tl_diffuse_color;
             }
         }

--- a/frontends/vray3dsMax/3dsMax/Eval.cpp
+++ b/frontends/vray3dsMax/3dsMax/Eval.cpp
@@ -9,10 +9,11 @@
 
 void EvalDiffuseFunc (const VUtils::VRayContext &rc,
     tlWeaveParameters *weave_parameters, VUtils::ShadeCol *diffuse_color,
-	tlYarnType* yarn_type, int* yarn_type_id)
+    float *diffuse_color_alpha, tlYarnType* yarn_type, int* yarn_type_id)
 {
     if(weave_parameters->pattern == 0){ //Invalid pattern
         *diffuse_color = VUtils::ShadeCol(1.f,1.f,0.f);
+        *diffuse_color_alpha = 1.f;
 		*yarn_type = tl_default_yarn_type;
 		*yarn_type_id = 0;
         return;
@@ -38,6 +39,7 @@ void EvalDiffuseFunc (const VUtils::VRayContext &rc,
     tlColor d = 
         tl_eval_diffuse( intersection_data, pattern_data, weave_parameters);
 	diffuse_color->set(d.r, d.g, d.b);
+    *diffuse_color_alpha = d.a;
 }
 
 void EvalSpecularFunc ( const VUtils::VRayContext &rc,

--- a/frontends/vray3dsMax/3dsMax/VrayThunderLoomBRDF.cpp
+++ b/frontends/vray3dsMax/3dsMax/VrayThunderLoomBRDF.cpp
@@ -13,8 +13,12 @@ using namespace VUtils;
 // throughout all directions, such as computing the diffuse color.
 void MyBaseBSDF::init(const VRayContext &rc, tlWeaveParameters *weave_parameters) {
     m_weave_parameters = weave_parameters;
-    EvalDiffuseFunc(rc,weave_parameters,&diffuse_color,&m_yarn_type,
-		&m_yarn_type_id);
+    EvalDiffuseFunc(rc,
+            weave_parameters,
+            &m_diffuse_color,
+            &m_diffuse_color_alpha,
+            &m_yarn_type,
+		    &m_yarn_type_id);
     orig_backside = rc.rayresult.realBack;
 
     const VR::VRayInterface &vri_const=static_cast<const VR::VRayInterface&>(rc);
@@ -39,7 +43,7 @@ VUtils::ShadeVec MyBaseBSDF::getDiffuseNormal(const VR::VRayContext &rc)
     return rc.rayresult.origNormal;
 }
 VUtils::ShadeCol MyBaseBSDF::getDiffuseColor(VUtils::ShadeCol &lightColor) {
-    VUtils::ShadeCol ret = diffuse_color*lightColor;
+    VUtils::ShadeCol ret = m_diffuse_color*lightColor;
 	lightColor.makeZero();
     return ret;
 }
@@ -49,12 +53,12 @@ VUtils::ShadeCol MyBaseBSDF::getLightMult(VUtils::ShadeCol &lightColor) {
         && m_weave_parameters->num_yarn_types > 0){
         s = m_weave_parameters->yarn_types[0].specular_color;
     }
-    VUtils::ShadeCol ret = (diffuse_color + VUtils::ShadeCol(s.r,s.g,s.b)) * lightColor;
+    VUtils::ShadeCol ret = (m_diffuse_color + VUtils::ShadeCol(s.r,s.g,s.b)) * lightColor;
     lightColor.makeZero();
     return ret;
 }
 VUtils::ShadeCol MyBaseBSDF::getTransparency(const VRayContext &rc) {
-	return VUtils::ShadeCol(0.f);
+	return VUtils::ShadeCol(1.f - m_diffuse_color_alpha);
 }
 
 ShadeCol MyBaseBSDF::eval( const VRayContext &rc, const ShadeVec &direction, ShadeCol &shadowedLight,
@@ -75,7 +79,7 @@ ShadeCol MyBaseBSDF::eval( const VRayContext &rc, const ShadeVec &direction, Sha
             //NOTE(Vidar): Multiple importance sampling factor
             k = cs*getReflectionWeight(probLight, probReflection);
         }
-        ret += diffuse_color * k;
+        ret += m_diffuse_color * k;
     }
     if((flags & FBRDF_SPECULAR) && ((rc.rayparams.rayType & RT_NOSPECULAR) == 0)){
         VUtils::ShadeCol reflect_color;
@@ -99,16 +103,16 @@ ShadeCol MyBaseBSDF::eval( const VRayContext &rc, const ShadeVec &direction, Sha
 //NOTE(Vidar): Called whenever a reflection ray is to be calculated
 void MyBaseBSDF::traceForward(VRayContext &rc, int doDiffuse) {
 	BRDFSampler::traceForward(rc, doDiffuse);
-	if (doDiffuse) rc.mtlresult.color+=rc.evalDiffuse()*diffuse_color;
+	if (doDiffuse) rc.mtlresult.color+=rc.evalDiffuse()*m_diffuse_color;
     Fragment *f=rc.mtlresult.fragment;
     if(f){
         VUtils::ShadeCol raw_gi=rc.evalDiffuse();
-        VUtils::ShadeCol diffuse_gi=raw_gi*diffuse_color;
+        VUtils::ShadeCol diffuse_gi=raw_gi*m_diffuse_color;
         f->setChannelDataByAlias(REG_CHAN_VFB_RAWGI,&raw_gi);
         f->setChannelDataByAlias(REG_CHAN_VFB_RAWTOTALLIGHT,&raw_gi);
         f->setChannelDataByAlias(REG_CHAN_VFB_GI,&diffuse_gi);
         f->setChannelDataByAlias(REG_CHAN_VFB_TOTALLIGHT,&diffuse_gi);
-        f->setChannelDataByAlias(REG_CHAN_VFB_DIFFUSE,&diffuse_color);
+        f->setChannelDataByAlias(REG_CHAN_VFB_DIFFUSE,&m_diffuse_color);
     }
 }
 

--- a/frontends/vray3dsMax/3dsMax/VrayThunderLoomBRDF.h
+++ b/frontends/vray3dsMax/3dsMax/VrayThunderLoomBRDF.h
@@ -8,7 +8,8 @@ namespace VUtils {
 
 class MyBaseBSDF: public BRDFSampler, public BSDFSampler {
 protected:
-	ShadeCol diffuse_color;
+	ShadeCol m_diffuse_color;
+	float m_diffuse_color_alpha;
 
 	ShadeVec normal, gnormal;
     int orig_backside;

--- a/src/pattern_editor.h
+++ b/src/pattern_editor.h
@@ -536,7 +536,7 @@ tlWeaveParameters *tl_pattern_editor(tlWeaveParameters *param)
                         ImGui::Text(#name); \
                         ImGui::Checkbox("",(bool*)&(yt+i)->name##_enabled); \
                         ImGui::SameLine(); \
-                        ImGui::ColorEdit3(" ",(float*)&(yt+i)->name); \
+                        ImGui::ColorEdit4(" ",(float*)&(yt+i)->name); \
                         ImGui::PopID(); 
 
                         TL_YARN_PARAMETERS

--- a/src/thunderloom.h
+++ b/src/thunderloom.h
@@ -30,7 +30,7 @@ void tl_prepare(tlWeaveParameters *params);
  * with the relevant information about the current shading point,
  * and call tl_shade to recieve the reflected color.
  */
-typedef struct {float r,g,b;} tlColor;
+typedef struct {float r,g,b,a;} tlColor;
 typedef struct tlIntersectionData tlIntersectionData;
 tlColor tl_shade(tlIntersectionData intersection_data,
         const tlWeaveParameters *params);
@@ -246,10 +246,10 @@ tlYarnType tl_default_yarn_type =
 	0.05f, //alpha
 	4.f,   //beta
 	0.3f,  //delta_x
-    {0.4f, 0.4f, 0.4f},  //specular color
+    {0.4f, 0.4f, 0.4f, 1.f},  //specular color
     1.f,   //specular_amount
     0.f,   //specular_noise
-    {0.3f, 0.3f, 0.3f},  //color
+    {0.3f, 0.3f, 0.3f, 1.f},  //color
     1.f,   //color_amount
     0
 };
@@ -1842,12 +1842,18 @@ tlColor tl_eval_diffuse(tlIntersectionData intersection_data,
     tlColor color = {
         yarn_type->color.r,
         yarn_type->color.g,
-        yarn_type->color.b
+        yarn_type->color.b,
+        yarn_type->color.a,
     };
 	if(yarn_type->color_texmap){
 		color = tl_eval_texmap_color(yarn_type->color_texmap,
             intersection_data.context);
 	}
+
+    // Pre-multiply alpha
+    color.r *= color.a;
+    color.g *= color.a;
+    color.b *= color.a;
 
     // Apply multiplier
     float color_amount = tl_yarn_type_get_color_amount(params, data.yarn_type,
@@ -1885,7 +1891,7 @@ tlColor tl_eval_diffuse(tlIntersectionData intersection_data,
 tlColor tl_eval_specular(tlIntersectionData intersection_data,
         tlPatternData data, const tlWeaveParameters *params)
 {
-    tlColor ret={0.f,0.f,0.f};
+    tlColor ret={0.f,0.f,0.f,1.f};
     // Depending on the given psi parameter the yarn is considered
     // staple or filament. They are treated differently in order
     // to work better numerically. 
@@ -1947,7 +1953,7 @@ float tl_eval_texmap_mono_lookup(void *texmap, float u, float v, void *context)
 
 tlColor tl_eval_texmap_color(void *texmap, void *context)
 {
-    tlColor ret = {1.f,1.f,1.f};
+    tlColor ret = {1.f,1.f,1.f,1.f};
     return ret;
 }
 #endif


### PR DESCRIPTION
tlColor struct now has alpha channel. 
But it is only used in the diffuse evaluation.
Plugins use alpha channel to tell vray about transparency.

Following still needs to be done...

- [ ] Expose alpha in 3dsmax UI for diffuse colors.
- [ ] Bump PTN file version. Make conversion pin file conversion function that adds alpha 1.0 to old colors.