### PR TITLE
Opacity channel for transparency

### DIFF
--- a/frontends/vray/vray_thunderloom.cpp
+++ b/frontends/vray/vray_thunderloom.cpp
@@ -28,7 +28,7 @@ struct BRDFThunderLoomParams: VRayParameterListDesc {
         addParamTexture("diffuse_color", Color(0.f, 0.3f, 0.f), -1, "Diffuse color.");
         addParamTextureFloat("diffuse_color_amount", 1.0f, -1, "Factor to multiply diffuse color with.");
         addParamTexture("opacity", Color(1.f,1.f,1.f), -1, "Opacity.");
-        addParamTexture("opacity_amount", Color(1.f,1.f,1.f), -1, "Factor to multiply opacity with.");
+        addParamTextureFloat("opacity_amount", 1.0f, -1, "Factor to multiply opacity with.");
         
         // Stored as lists, just like above. These parameters allow us to 
         // specify what parameters we want to override, for a specific yarn.
@@ -44,7 +44,7 @@ struct BRDFThunderLoomParams: VRayParameterListDesc {
         addParamBool("diffuse_color_on",            false, -1, "");
         addParamBool("diffuse_color_amount_on",     false, -1, "");
         addParamBool("opacity_on",                  false, -1, "");
-        addParamBool("opacity_amount_on",            false, -1, "");
+        addParamBool("opacity_amount_on",           false, -1, "");
 
         // MAYA FIX
         // It seems that only float params can be retrieved from Maya into the 
@@ -61,7 +61,7 @@ struct BRDFThunderLoomParams: VRayParameterListDesc {
         addParamTextureFloat("highlight_width_on_float",       false, -1, "");
         addParamTextureFloat("diffuse_color_on_float",         false, -1, "");
         addParamTextureFloat("diffuse_color_amount_on_float",  false, -1, "");
-        addParamTextureFloat("opacity_on_float",               false, -1, "");
+        addParamTextureFloat("opacity_on_float",         false, -1, "");
         addParamTextureFloat("opacity_amount_on_float",        false, -1, "");
         
         addParamFloat("bends2", 0.5f, -1, "");
@@ -283,7 +283,7 @@ TL_VRAY_FLOAT_PARAMS
             yarn_type->color_enabled = get_bool(diffuse_color_on_float, i, rc);
 
         if (is_param_valid(opacity, i)) {
-            if (!set_texparam(opacity, &yarn_type->color_texmap, i)) {
+            if (!set_texparam(opacity, &yarn_type->opacity_texmap, i)) {
                 Color tmp_opacity = opacity->getColor(i);
                 tlColor tl_opacity;
                 tl_opacity.r = tmp_opacity.r; tl_opacity.g = tmp_opacity.g; tl_opacity.b = tmp_opacity.b;

--- a/frontends/vray/vray_thunderloom.h
+++ b/frontends/vray/vray_thunderloom.h
@@ -28,8 +28,10 @@ class BRDFThunderLoomSampler: public VR::BRDFSampler, public VR::BSDFSampler {
     VR::ShadeVec m_uv;
     VR::ShadeTransform m_uv_tm;
     VR::ShadeCol m_diffuse_color;
+    VR::ShadeCol m_opacity_color;
     tlYarnType m_yarn_type;
     int m_yarn_type_id;
+	int m_yarn_hit;
 
 public:
     // Initialization
@@ -108,6 +110,8 @@ struct YarnCache {
     VR::VRayPluginList specular_noise;
     VR::VRayPluginList highlight_width;
     VR::VRayPluginList diffuse_color_amount;
+    VR::VRayPluginList opacity;
+    VR::VRayPluginList opacity_amount;
 
     VR::IntList bend_on;
     VR::IntList yarnsize_on;
@@ -120,6 +124,8 @@ struct YarnCache {
     VR::IntList highlight_width_on;
     VR::IntList diffuse_color_on;
     VR::IntList diffuse_color_amount_on;
+    VR::IntList opacity_on;
+    VR::IntList opacity_amount_on;
 };
 
 

--- a/frontends/vray/vray_thunderloom.h
+++ b/frontends/vray/vray_thunderloom.h
@@ -110,7 +110,6 @@ struct YarnCache {
     VR::VRayPluginList specular_noise;
     VR::VRayPluginList highlight_width;
     VR::VRayPluginList diffuse_color_amount;
-    VR::VRayPluginList opacity;
     VR::VRayPluginList opacity_amount;
 
     VR::IntList bend_on;

--- a/frontends/vray/vray_thunderloom_updated.cpp
+++ b/frontends/vray/vray_thunderloom_updated.cpp
@@ -25,8 +25,8 @@ BRDFThunderLoomParamsUpdated::BRDFThunderLoomParamsUpdated(void) {
 	addParamPlugin("highlight_width", EXT_TEXTURE_FLOAT, 0, "Width over which to average the specular reflections. Gives wider highlight streaks on the yarns.");
 	addParamTexture("diffuse_color", Color(0.f, 0.3f, 0.f), 0, "Diffuse color.");
 	addParamPlugin("diffuse_color_amount", EXT_TEXTURE_FLOAT, 0, "Factor to multiply diffuse color with.");
-	addParamTexture("opacity", Color(1.f,1.f,1.f), -1, "Opacity.");
-	addParamTexture("opacity_amount", Color(1.f,1.f,1.f), -1, "Factor to multiply opacity with.");
+	addParamTexture("opacity", Color(1.f,1.f,1.f), 0, "Opacity.");
+	addParamPlugin("opacity_amount", EXT_TEXTURE_FLOAT, 0, "Factor to multiply opacity with.");
 	
 	// Stored as lists, just like above. These parameters allow us to 
 	// specify what parameters we want to override, for a specific yarn.
@@ -41,7 +41,7 @@ BRDFThunderLoomParamsUpdated::BRDFThunderLoomParamsUpdated(void) {
 	addParamBool("highlight_width_on",          false, 0, "");
 	addParamBool("diffuse_color_on",            false, 0, "");
 	addParamBool("diffuse_color_amount_on",     false, 0, "");
-	addParamBool("opacity_on",                  false, 0, "");
+	addParamBool("opacity_on",            false, 0, "");
 	addParamBool("opacity_amount_on",           false, 0, "");
 }
 
@@ -161,6 +161,7 @@ void BRDFThunderLoomUpdated::frameBegin(VRayRenderer *vray) {
         TL_VRAY_INIT_PARAM(specular_color_amount)\
         TL_VRAY_INIT_PARAM(specular_noise)\
         TL_VRAY_INIT_PARAM(diffuse_color_amount)\
+        TL_VRAY_INIT_PARAM(opacity_amount)\
 
     TL_VRAY_FLOAT_PARAMS
 
@@ -221,15 +222,15 @@ TL_VRAY_FLOAT_PARAMS
             yarn_type->color_enabled = yarnCache.diffuse_color_on[i];
 
         if (is_param_valid(opacity, i)) {
-            if (!set_texparam(opacity, &yarn_type->color_texmap, i)) {
+            if (!set_texparam(opacity, &yarn_type->opacity_texmap, i)) {
                 Color tmp_opacity = opacity->getColor(i);
                 tlColor tl_opacity;
                 tl_opacity.r = tmp_opacity.r; tl_opacity.g = tmp_opacity.g; tl_opacity.b = tmp_opacity.b;
-                yarn_type->color = tl_opacity;
+                yarn_type->opacity = tl_opacity;
             }
         }
         if (yarnCache.opacity_on.count() > i)
-            yarn_type->color_enabled = yarnCache.opacity_on[i];
+            yarn_type->opacity_enabled = yarnCache.opacity_on[i];
     }
 
     tl_prepare(m_tl_wparams);

--- a/frontends/vray3dsMax/3dsMax/3dsMaxThunderLoom.cpp
+++ b/frontends/vray3dsMax/3dsMax/3dsMaxThunderLoom.cpp
@@ -454,7 +454,9 @@ INT_PTR YarnTypeDlgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 				TL_FLOAT_PARAM(delta_x)\
 				TL_COLOR_PARAM(specular_color)\
 				TL_FLOAT_PARAM(specular_noise)\
-			    TL_COLOR_PARAM(color)
+			    TL_COLOR_PARAM(color)\
+			    TL_COLOR_PARAM(opacity)\
+//
 
             //NOTE(Vidar): Setup spinners
             #define TL_FLOAT_PARAM(name){\

--- a/frontends/vray3dsMax/3dsMax/3dsMaxThunderLoom.h
+++ b/frontends/vray3dsMax/3dsMax/3dsMaxThunderLoom.h
@@ -33,7 +33,8 @@
 #define YARN_TYPE_TEXMAP_PARAMETERS\
 	YARN_TYPE_TEXMAP(color)\
 	YARN_TYPE_TEXMAP(specular_color)\
-	YARN_TYPE_TEXMAP(yarnsize)
+	YARN_TYPE_TEXMAP(yarnsize)\
+	YARN_TYPE_TEXMAP(opacity)
 enum {
 #define YARN_TYPE_TEXMAP(param) yrn_texmaps_##param,
 	YARN_TYPE_TEXMAP_PARAMETERS

--- a/frontends/vray3dsMax/3dsMax/Eval.cpp
+++ b/frontends/vray3dsMax/3dsMax/Eval.cpp
@@ -9,12 +9,16 @@
 
 void EvalDiffuseFunc (const VUtils::VRayContext &rc,
     tlWeaveParameters *weave_parameters, VUtils::ShadeCol *diffuse_color,
-	tlYarnType* yarn_type, int* yarn_type_id)
+	VUtils::ShadeCol *opacity_color,
+	tlYarnType* yarn_type, int* yarn_type_id,
+	int *yarn_hit)
 {
     if(weave_parameters->pattern == 0){ //Invalid pattern
         *diffuse_color = VUtils::ShadeCol(1.f,1.f,0.f);
+        *opacity_color = VUtils::ShadeCol(1.f,1.f,1.f);
 		*yarn_type = tl_default_yarn_type;
 		*yarn_type_id = 0;
+		*yarn_hit = 0;
         return;
     }
     tlIntersectionData intersection_data;
@@ -35,9 +39,13 @@ void EvalDiffuseFunc (const VUtils::VRayContext &rc,
         weave_parameters);
 	*yarn_type_id = pattern_data.yarn_type;
 	*yarn_type = weave_parameters->yarn_types[pattern_data.yarn_type];
+	*yarn_hit = pattern_data.yarn_hit;
     tlColor d = 
         tl_eval_diffuse( intersection_data, pattern_data, weave_parameters);
 	diffuse_color->set(d.r, d.g, d.b);
+    tlColor o = 
+        tl_eval_opacity( intersection_data, pattern_data, weave_parameters);
+	opacity_color->set(o.r, o.g, o.b);
 }
 
 void EvalSpecularFunc ( const VUtils::VRayContext &rc,

--- a/frontends/vray3dsMax/3dsMax/Eval.h
+++ b/frontends/vray3dsMax/3dsMax/Eval.h
@@ -21,7 +21,10 @@
 
 void EvalDiffuseFunc (const VUtils::VRayContext &rc,
     tlWeaveParameters *weave_parameters, VUtils::ShadeCol *diffuse_color,
-	tlYarnType *yarn_type, int *yarn_type_id);
+	VUtils::ShadeCol *opacity_color,
+	tlYarnType* yarn_type, int* yarn_type_id,
+	int *yarn_hit)
+;
 
 void EvalSpecularFunc(const VUtils::VRayContext &rc,
 	const VUtils::ShadeVec &direction, tlWeaveParameters *weave_parameters, VUtils::ShadeCol *reflection_color) ;

--- a/frontends/vray3dsMax/3dsMax/VrayThunderLoomBRDF.h
+++ b/frontends/vray3dsMax/3dsMax/VrayThunderLoomBRDF.h
@@ -8,7 +8,8 @@ namespace VUtils {
 
 class MyBaseBSDF: public BRDFSampler, public BSDFSampler {
 protected:
-	ShadeCol diffuse_color;
+	ShadeCol m_diffuse_color;
+	ShadeCol m_opacity_color;
 
 	ShadeVec normal, gnormal;
     int orig_backside;
@@ -17,6 +18,7 @@ protected:
 	Texmap **m_texmaps;
 	tlYarnType m_yarn_type;
 	int m_yarn_type_id;
+	int m_yarn_hit;
 
 public:
 

--- a/frontends/vray3dsMax/3dsMax/resource.h
+++ b/frontends/vray3dsMax/3dsMax/resource.h
@@ -185,6 +185,9 @@
 #define IDC_YRN_TEX_yarnsize_BUTTON     1200
 #define IDC_YRN_TEX_specular_color_BUTTON 1202
 #define IDC_specular_LABEL 1203
+#define IDC_opacity_SWATCH 1204
+#define IDC_YRN_TEX_opacity_BUTTON 1205
+#define IDC_opacity_OVERRIDE 1206
 
 // Next default values for new objects
 // 

--- a/frontends/vray3dsMax/3dsMax/vrayblinnmtl.rc
+++ b/frontends/vray3dsMax/3dsMax/vrayblinnmtl.rc
@@ -111,8 +111,8 @@ BEGIN
                     "CustButton",WS_TABSTOP,121,14,83,11
     CONTROL         "Custom2",IDC_USCALE_EDIT,"CustEdit",0x0,37,28,22,10
     CONTROL         "Custom3",IDC_USCALE_SPIN,"SpinnerControl",WS_TABSTOP,61,28,7,10
-    CONTROL         "Custom2",IDC_VSCALE_EDIT,"CustEdit",WS_TABSTOP,81,28,21,10
-    CONTROL         "Custom3",IDC_VSCALE_SPIN,"SpinnerControl",0x0,104,28,7,10
+    CONTROL         "Custom2",IDC_VSCALE_EDIT,"CustEdit",0x0,81,28,21,10
+    CONTROL         "Custom3",IDC_VSCALE_SPIN,"SpinnerControl",WS_TABSTOP,104,28,7,10
     CONTROL         "",IDC_REALWORLD_CHECK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,148,28,16,10
     CONTROL         "Custom2",IDC_UVROTATION_EDIT,"CustEdit",WS_TABSTOP,184,28,21,10
     CONTROL         "Custom3",IDC_UVROTATION_SPIN,"SpinnerControl",0x0,207,28,7,10
@@ -147,11 +147,14 @@ BEGIN
     LTEXT           "Diffuse color",IDC_STATIC,11,4,40,8
     LTEXT           "Specular noise",IDC_STATIC,11,18,48,8
     LTEXT           "Uniform spec.",IDC_alpha_LABEL,112,44,44,8
+    LTEXT           "Opacity",IDC_STATIC,11,43,40,8
     CONTROL         "Custom2",IDC_alpha_EDIT,"CustEdit",WS_TABSTOP,174,43,23,10
     CONTROL         "Custom3",IDC_alpha_SPIN,"SpinnerControl",0x0,197,43,7,10
+    CONTROL         "Custom1",IDC_opacity_SWATCH,"ColorSwatch",0x0,70,43,16,12
+    CONTROL         "",IDC_YRN_TEX_opacity_BUTTON,"CustButton",WS_TABSTOP,90,43,14,10
 END
 
-IDD_YARN_TYPE DIALOGEX 0, 0, 220, 59
+IDD_YARN_TYPE DIALOGEX 0, 0, 220, 72
 STYLE DS_SETFONT | WS_CHILD | WS_VISIBLE
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
@@ -180,6 +183,9 @@ BEGIN
     CONTROL         "Uniform spec.",IDC_alpha_OVERRIDE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,116,43,60,10
     CONTROL         "Custom2",IDC_alpha_EDIT,"CustEdit",WS_TABSTOP,176,43,22,10
     CONTROL         "Custom3",IDC_alpha_SPIN,"SpinnerControl",0x0,198,43,7,10
+    CONTROL         "Opacity",IDC_opacity_OVERRIDE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,56,55,10
+    CONTROL         "Custom1",IDC_opacity_SWATCH,"ColorSwatch",0x0,70,56,16,12
+    CONTROL         "",IDC_YRN_TEX_opacity_BUTTON,"CustButton",WS_TABSTOP,90,56,14,10
 END
 
 


### PR DESCRIPTION
Modified pr #36 to use a separate parameter for opacity - instead of alpha channel
Only tested in 3ds Max for now.

Here's a material with yarn size 0.3 (and transparency between the yarns):
![tl_opacity](https://user-images.githubusercontent.com/1567540/77765066-fdb47700-703d-11ea-897a-1da9ecac2e08.png)
